### PR TITLE
Create account for newly generated user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,13 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
 
   has_one :account
+
+  after_create :create_account
+
+  private
+
+  def create_account
+    self.account = Account.create(user: self, balance: 0)
+    true
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe User, type: :model do
 
     expect(association.macro).to eq(:has_one)
   end
+
+  it 'creates a new for a newly created user' do
+    user = described_class.create(email: 'foo@example.com', password: '12345678')
+
+    expect(user.account).to be_present
+    expect(user.account.balance).to eq(0)
+  end
 end


### PR DESCRIPTION
Sets up account creation for newly created users. So when a user registers on the system, he/she also gets an account with balance zero.